### PR TITLE
fix: DSL2 optional-output syntax for Nextflow 25.x + clamp version

### DIFF
--- a/modules/local/msstats/main.nf
+++ b/modules/local/msstats/main.nf
@@ -15,7 +15,7 @@ process MSSTATS {
     output:
     // The generation of the PDFs from MSstats are very unstable, especially with auto-contrasts.
     // And users can easily fix anything based on the csv and the included script -> make optional
-    path "*.pdf" optional true
+    path "*.pdf", optional: true
     path "*.csv", emit: msstats_csv
     path "*.log", emit: log
     path "versions.yml" , emit: version

--- a/modules/local/msstatstmt/main.nf
+++ b/modules/local/msstatstmt/main.nf
@@ -15,7 +15,7 @@ process MSSTATSTMT {
     output:
     // The generation of the PDFs from MSstatsTMT are very unstable, especially with auto-contrasts.
     // And users can easily fix anything based on the csv and the included script -> make optional
-    path "*.pdf" optional true
+    path "*.pdf", optional: true
     path "*.csv", emit: msstats_csv
     path "*.log"
     path "versions.yml" , emit: version

--- a/modules/local/openms/proteomicslfq/main.nf
+++ b/modules/local/openms/proteomicslfq/main.nf
@@ -17,14 +17,14 @@ process PROTEOMICSLFQ {
     output:
     path "${expdes.baseName}_openms.mzTab", emit: out_mztab
     path "${expdes.baseName}_openms.consensusXML", emit: out_consensusXML
-    path "*msstats_in.csv", emit: out_msstats optional true
-    path "*triqler_in.tsv", emit: out_triqler optional true
-    path "debug_mergedIDs.idXML", emit: debug_mergedIDs optional true
-    path "debug_mergedIDs_inference.idXML", emit: debug_mergedIDs_inference optional true
-    path "debug_mergedIDsGreedyResolved.idXML", emit: debug_mergedIDsGreedyResolved optional true
-    path "debug_mergedIDsGreedyResolvedFDR.idXML", emit: debug_mergedIDsGreedyResolvedFDR optional true
-    path "debug_mergedIDsGreedyResolvedFDRFiltered.idXML", emit: debug_mergedIDsGreedyResolvedFDRFiltered optional true
-    path "debug_mergedIDsFDRFilteredStrictlyUniqueResolved.idXML", emit: debug_mergedIDsFDRFilteredStrictlyUniqueResolved optional true
+    path "*msstats_in.csv", emit: out_msstats, optional: true
+    path "*triqler_in.tsv", emit: out_triqler, optional: true
+    path "debug_mergedIDs.idXML", emit: debug_mergedIDs, optional: true
+    path "debug_mergedIDs_inference.idXML", emit: debug_mergedIDs_inference, optional: true
+    path "debug_mergedIDsGreedyResolved.idXML", emit: debug_mergedIDsGreedyResolved, optional: true
+    path "debug_mergedIDsGreedyResolvedFDR.idXML", emit: debug_mergedIDsGreedyResolvedFDR, optional: true
+    path "debug_mergedIDsGreedyResolvedFDRFiltered.idXML", emit: debug_mergedIDsGreedyResolvedFDRFiltered, optional: true
+    path "debug_mergedIDsFDRFilteredStrictlyUniqueResolved.idXML", emit: debug_mergedIDsFDRFilteredStrictlyUniqueResolved, optional: true
     path "*.log", emit: log
     path "versions.yml", emit: version
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -443,7 +443,7 @@ manifest {
     homePage        = 'https://github.com/nf-core/quantms'
     description     = """Quantitative Mass Spectrometry nf-core workflow"""
     mainScript      = 'main.nf'
-    nextflowVersion = '!>=23.04.0'
+    nextflowVersion = '!>=25.04.0'
     version         = '1.2.0'
     doi             = '10.5281/zenodo.7754148'
 }


### PR DESCRIPTION
## Root cause

Our AWS Batch runner image was bumped to `nextflow/nextflow:25.10.4` (required so `env()` works in the SCM config). On 25.x, Nextflow parses the bareword DSL2 process-output form

```groovy
path "<glob>" optional true
```

as `path("<glob>").optional(true)`. The inner call now returns `null`, so `.optional(true)` throws at **script-load / include time**:

```
java.lang.NullPointerException: Cannot invoke method optional() on null object
  at ...BaseScript.process(BaseScript.groovy:136)
```

Because this fires while **parsing an include** (not at runtime), a single offending module aborts the entire pipeline before any workflow runs — even modules for paths we never execute. Confirmed originally on rev `de14f523`: first failure at `modules/local/msstatstmt/main.nf` (`path "*.pdf" optional true`), which killed a DIA/LFQ job that never intended to touch TMT.

It worked before only because the old runner ran an older Nextflow.

## Fix

Convert every bareword occurrence to the modern comma+colon form (`, optional: true`). Lines already using `, optional: true` (multiqc, pmultiqc, proteinquantifier) were left alone.

| File | Line(s) | Change |
|------|---------|--------|
| `modules/local/msstats/main.nf` | 18 | `path "*.pdf" optional true` → `path "*.pdf", optional: true` |
| `modules/local/msstatstmt/main.nf` | 18 | `path "*.pdf" optional true` → `path "*.pdf", optional: true` |
| `modules/local/openms/proteomicslfq/main.nf` | 20–27 | 8 outputs `... emit: X optional true` → `... emit: X, optional: true` |
| `nextflow.config` | 446 | `nextflowVersion = '!>=23.04.0'` → `nextflowVersion = '!>=25.04.0'` |

The version clamp matches the runner; `!` enforces it.

## Verification

Under **Nextflow 25.10.4**, `nextflow inspect main.nf -profile test,docker` loads the full include graph and resolves cleanly — no `optional()` NPE. **41 processes** resolved, including the previously-broken `MSSTATS`, `MSSTATSTMT`, `PROTEOMICSLFQ`, plus all TMT/DIA-NN modules.

Direct before/after on the offending module (25.10.4):

```
=== BROKEN (git HEAD) ===
ERROR ~ Cannot invoke method optional() on null object
=== FIXED (this branch) ===
Launching `repro_fixed.nf` [gloomy_murdock] DSL2 - revision: 6e528479d6   # clean, no NPE
```

`nextflow inspect` output (head):

```json
{
    "processes": [
        { "name": "SILICOLIBRARYGENERATION", "container": "docker.io/biocontainers/diann:v1.8.1_cv1" },
        { "name": "SEARCHENGINESAGE", "container": "quay.io/biocontainers/openms-thirdparty:3.1.0--h9ee0642_1" },
        ...
        { "name": "MSSTATS", ... },
        { "name": "PROTEOMICSLFQ", ... },
        { "name": "MSSTATSTMT", ... },
        { "name": "DIANNSUMMARY", "container": "docker.io/biocontainers/diann:v1.8.1_cv1" }
    ]
}
```

exit=0, zero errors/exceptions in stderr.

## Scope

Fork-only — not pushed upstream (nf-core / bigbio). This fork carries DIA-NN in-workflow, which upstream dropped.